### PR TITLE
Fixing NameError in notebook 2

### DIFF
--- a/auto_mpg_prediction-part2.ipynb
+++ b/auto_mpg_prediction-part2.ipynb
@@ -918,7 +918,7 @@
     "        ('std_scaler', StandardScaler()),\n",
     "    ])\n",
     "\n",
-    "num_data_tr = num_pipeline.fit_transform(data_num)\n",
+    "num_data_tr = num_pipeline.fit_transform(num_data)\n",
     "num_data_tr[0]"
    ]
   },


### PR DESCRIPTION
Fixing variable name in first cell under "Creating a Pipeline of tasks" 